### PR TITLE
Bugfix/ignore analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,16 @@ MIX_BADASO_MENU=admin,badaso-blog-module
 8. Select **KEYS** menu from the tab. Click Add Key and select **Create new key**. After that, select JSON and click **Create** button.
 ![Imgur](https://i.imgur.com/oexLid9.png)
 
-9. After you create the key, it'll automatically download the key. Store your key in the safe place.
+9. After you create the key, it'll automatically download the key.
+10. Place your .json key to storage directory like below.
+
+```php
+📦 Your Project
+ ┣ 📂 storage
+ ┃ ┣ 📂 app
+ ┃ ┃ ┣ 📂 analytics // If the directory doesn't exists, just create it
+ ┃ ┃ ┃ ┗ 📜 service-account-credentials.json // Filename must be the same
+```
 
 ## Granting permissions to your Analytics property
 

--- a/src/Controllers/CommentController.php
+++ b/src/Controllers/CommentController.php
@@ -86,7 +86,7 @@ class CommentController extends Controller
 
                 return ApiResponse::success($comment_with_user);
             } else {
-                return ApiResponse::failed(__('badaso-blog::validation.auth.user_not_logged_in'));
+                return ApiResponse::failed(__('badaso_blog::validation.auth.user_not_logged_in'));
             }
         } catch (Exception $e) {
             DB::rollback();

--- a/src/Helpers/GetData.php
+++ b/src/Helpers/GetData.php
@@ -4,6 +4,7 @@ namespace Uasoft\Badaso\Module\Blog\Helpers;
 
 use Carbon\Carbon;
 use Spatie\Analytics\Period;
+use Uasoft\Badaso\Exceptions\SingleException;
 
 class GetData
 {
@@ -200,6 +201,11 @@ class GetData
     private static function getToken()
     {
         $credential_path = storage_path('app/analytics/service-account-credentials.json');
+
+        if (!file_exists($credential_path)) {
+            throw new SingleException(__('badaso_blog::validation.analytics.no_service_account'));
+        }
+        
         $client = new \Google\Client();
         $client->setAuthConfig($credential_path);
 

--- a/src/Providers/BadasoBlogModuleServiceProvider.php
+++ b/src/Providers/BadasoBlogModuleServiceProvider.php
@@ -27,7 +27,7 @@ class BadasoBlogModuleServiceProvider extends ServiceProvider
 
         $this->loadMigrationsFrom(__DIR__.'/../Migrations');
         $this->loadRoutesFrom(__DIR__.'/../Routes/api.php');
-        $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'badaso-blog');
+        $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'badaso_blog');
 
         $this->publishes([
             __DIR__.'/../Config/badaso-blog.php' => config_path('badaso-blog.php'),

--- a/src/resources/lang/en/validation.php
+++ b/src/resources/lang/en/validation.php
@@ -4,4 +4,7 @@ return [
     'auth' => [
         'user_not_logged_in' => 'User is not logged in.',
     ],
+    'analytics' => [
+        'no_service_account' => 'No service account credentials found.'
+    ]
 ];

--- a/src/resources/lang/id/validation.php
+++ b/src/resources/lang/id/validation.php
@@ -4,4 +4,7 @@ return [
     'auth' => [
         'user_not_logged_in' => 'User belum login.',
     ],
+    'analytics' => [
+        'no_service_account' => 'Tidak ada service account credentials yang ditemukan.'
+    ]
 ];


### PR DESCRIPTION
- Change `getToken` behavior, now it'll throw exception when `service-account-credentials.json` not found. Close #29.
- Add directory structure on readme.md.
- Fix translation from `resources/lang` directory not found.